### PR TITLE
He agregado un ejemplo del path de Windows al ingresar la ruta

### DIFF
--- a/GeneradorCedulas/src/github/GeneradorCedulas_App.java
+++ b/GeneradorCedulas/src/github/GeneradorCedulas_App.java
@@ -27,6 +27,7 @@ public class GeneradorCedulas_App {
         System.out.println("Bienvenid@ al Generador de cédulas ecuatorianas  Por favor, ingrese la \n"
 							+ "ubicación donde quiera guardar el diccionario generado y asegurese \n"
         					+ "de que tenga permisos de escritura: \n"
+							+ " Ejemplo: C:/Users/MiUsuario/Documentos (en Windows) \n"
 							+ " Ejemplo: /home/MiUsuario/Documentos (en Linux): ");
         
         


### PR DESCRIPTION
Se agregó un path de ejemplo para que los usuarios de Windows sepan el formato de archivos que tienen que colocar y no perder tiempo haciendo pruebas en sus equipos.